### PR TITLE
Fix prune() to remove nodes with no outgoing edges

### DIFF
--- a/src/eap/graph.py
+++ b/src/eap/graph.py
@@ -579,8 +579,8 @@ class Graph:
             nodes_with_outgoing = self.in_graph.any(dim=1)
             nodes_with_ingoing = einsum(self.in_graph.any(dim=0).float(), self.forward_to_backward.float(), 'backward, forward backward -> forward') > 0
             nodes_with_ingoing[0] = True  # input node always treated as if it has incoming edges
-            new_nodes_in_graph = nodes_with_outgoing & nodes_with_ingoing
-            self.nodes_in_graph[:] = new_nodes_in_graph
+            old_nodes_in_graph = self.nodes_in_graph.clone()
+            self.nodes_in_graph[:] = nodes_with_outgoing & nodes_with_ingoing
             
             # remove edges with missing parents or children
             forward_in_graph = self.nodes_in_graph.float()
@@ -589,7 +589,10 @@ class Graph:
             edge_remask = einsum(forward_in_graph, backward_in_graph, 'forward, backward -> forward backward') > 0
             old_edges_in_graph = self.in_graph.clone()
             self.in_graph *= edge_remask
-            old_new_same = torch.all(new_nodes_in_graph == self.nodes_in_graph) and torch.all(old_edges_in_graph == self.in_graph)
+            old_new_same = (
+                torch.all(old_nodes_in_graph == self.nodes_in_graph) and
+                torch.all(old_edges_in_graph == self.in_graph)
+            )
             
         # remove neurons from nodes not in the graph
         if self.neurons_in_graph is not None:


### PR DESCRIPTION
This pull request addresses Issue #16.

It fixes a bug in `graph.py` where nodes with no outgoing edges (i.e., no children) could remain in the graph after calling `g.apply_topn(...)`.

### Summary of fix
In the `prune()` method, the loop exit condition now also checks whether the `in_graph` edge mask has changed, in addition to `nodes_in_graph`. This prevents premature exit of the pruning loop.

### Example
After this fix, calling:

```python
g.apply_topn(50, True)
```

in `greater_than.ipynb` correctly removes node `m4` from the graph.

Let me know if you have any questions or suggestions. Thanks!